### PR TITLE
- For security's sake, we shall keep our environment variables out of…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,8 @@ typings/
 # dotenv environment variables file
 .env
 .env.test
+.env.dev
+dotenv
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -27,7 +27,7 @@
 
     <title>TransPort</title>
     <script
-    src="https://maps.googleapis.com/maps/api/js?key={API_KEY_HERE}"
+    src="%REACT_APP_GOOGLE_MAPS_API_KEY%"
     async
     >
     </script>

--- a/server/server.js
+++ b/server/server.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const app = express();
+require('dotenv').config();
 
 // Port will either be 4000 by default or, if 4000 is in-use, another available port;
 const port = 4000 || process.env.PORT;
@@ -9,8 +10,7 @@ const HttpError = require(`./models/http-error`);
 
 // Database connection
 const mongoose = require('mongoose');
-
-const url = 'mongodb+srv://{ENTER CONNECTION STRING FROM MONGODB HERE}';
+const url = process.env.DB_URL;
 
 // Routing middleware imports
 const staticRoutes = require('./routes/static-routes');  // Not 100% sure I'll need this
@@ -67,7 +67,7 @@ app.use((error, req, res, next) => {
 // Connect to database server
 mongoose.set('useUnifiedTopology', true);
 mongoose
-  .connect(url)
+  .connect(`${url}`)
   .then(
     // Listens on an available port
     app.listen(port, () => {


### PR DESCRIPTION
… Github;

- in /server/server/js: to access 'url' value; create a file called .env and include DB_URL= , and write your MongoDB connection string with yr credentials into it; now, server.js can access that from there;
- in /client: create a .env file with REACT_APP_GOOGLE_MAPS_API_KEY= in it and with your Google Maps API (or potentially other map API key), and then:
----- in /client/public/index.html: change line 30 to read:    src="%REACT_APP_GOOGLE_MAPS_API_KEY%"
- That's it!  .env and all related are also included in .gitignore now, so they shouldn't be staged with git commits now, and yr app can refer to them with the appropriate config files;
Bonne soirée!!! J'aime mon ordinateur.

<3, vita

Oh, and two more things!
* run `npm i dotenv --save-dev` to install dotenv module from npm
* okay maybe that was it, nevermiiind
* closes #94 